### PR TITLE
Adds dbRefresh for Drupal 

### DIFF
--- a/src/Robo/Drupal/BaseDrupal.php
+++ b/src/Robo/Drupal/BaseDrupal.php
@@ -14,4 +14,13 @@ abstract class BaseDrupal extends Base {
    */
   abstract public function setup();
 
+  /**
+   * Run Drush cim after pull.
+   */
+  public function dbRefresh() {
+    $this->dbGet();
+    $this->_exec('docker-compose exec --user=82 php /usr/local/bin/drush sql-drop -y');
+    $this->_exec('docker-compose exec --user=82 php /usr/local/bin/drush sql-cli < mariadb-init/dump.sql');
+  }
+
 }

--- a/src/Robo/Drupal/BaseDrupal.php
+++ b/src/Robo/Drupal/BaseDrupal.php
@@ -20,11 +20,11 @@ abstract class BaseDrupal extends Base {
   public function dbRefresh() {
     $this->dbGet();
     if ($this->getXenoVersion() == '') {
-      $this->_exec('docker-compose exec --user=82 php drush sql-drop --root=/var/www/html/web -y');
-      $this->_exec('docker-compose exec --user=82 php drush sql-cli < mariadb-init/dump.sql --root=/var/www/html/web');
+      $this->_exec('docker-compose exec --user=82 php sh -c "drush sql-drop --root=/var/www/html/web -y"');
+      $this->_exec('docker-compose exec --user=82 php sh -c "drush sql-cli < mariadb-init/dump.sql --root=/var/www/html/web"');
     } else {
       $this->_exec('docker-compose exec php drush sql-drop --root=/var/www/html/web -y');
-      $this->_exec('docker-compose exec php drush sql-cli < mariadb-init/dump.sql --root=/var/www/html/web');
+      $this->_exec('docker-compose exec php sh -c "drush sql-cli < mariadb-init/dump.sql --root=/var/www/html/web"');
     }
 
   }

--- a/src/Robo/Drupal/BaseDrupal.php
+++ b/src/Robo/Drupal/BaseDrupal.php
@@ -19,8 +19,14 @@ abstract class BaseDrupal extends Base {
    */
   public function dbRefresh() {
     $this->dbGet();
-    $this->_exec('docker-compose exec --user=82 php /usr/local/bin/drush sql-drop --root=/var/www/html/web -y');
-    $this->_exec('docker-compose exec --user=82 php /usr/local/bin/drush sql-cli < mariadb-init/dump.sql --root=/var/www/html/web');
+    if ($this->getXenoVersion() == '') {
+      $this->_exec('docker-compose exec --user=82 php drush sql-drop --root=/var/www/html/web -y');
+      $this->_exec('docker-compose exec --user=82 php drush sql-cli < mariadb-init/dump.sql --root=/var/www/html/web');
+    } else {
+      $this->_exec('docker-compose exec php drush sql-drop --root=/var/www/html/web -y');
+      $this->_exec('docker-compose exec php drush sql-cli < mariadb-init/dump.sql --root=/var/www/html/web');
+    }
+
   }
 
 }

--- a/src/Robo/Drupal/BaseDrupal.php
+++ b/src/Robo/Drupal/BaseDrupal.php
@@ -19,8 +19,8 @@ abstract class BaseDrupal extends Base {
    */
   public function dbRefresh() {
     $this->dbGet();
-    $this->_exec('docker-compose exec --user=82 php /usr/local/bin/drush sql-drop --root=web -y');
-    $this->_exec('docker-compose exec --user=82 php /usr/local/bin/drush sql-cli < mariadb-init/dump.sql --root=web');
+    $this->_exec('docker-compose exec --user=82 php /usr/local/bin/drush sql-drop --root=/var/www/html/web -y');
+    $this->_exec('docker-compose exec --user=82 php /usr/local/bin/drush sql-cli < mariadb-init/dump.sql --root=/var/www/html/web');
   }
 
 }

--- a/src/Robo/Drupal/BaseDrupal.php
+++ b/src/Robo/Drupal/BaseDrupal.php
@@ -15,12 +15,12 @@ abstract class BaseDrupal extends Base {
   abstract public function setup();
 
   /**
-   * Run Drush cim after pull.
+   * Pull DB Backup and refresh.
    */
   public function dbRefresh() {
     $this->dbGet();
-    $this->_exec('docker-compose exec --user=82 php /usr/local/bin/drush sql-drop -y');
-    $this->_exec('docker-compose exec --user=82 php /usr/local/bin/drush sql-cli < mariadb-init/dump.sql');
+    $this->_exec('docker-compose exec --user=82 php /usr/local/bin/drush sql-drop --root=web -y');
+    $this->_exec('docker-compose exec --user=82 php /usr/local/bin/drush sql-cli < mariadb-init/dump.sql --root=web');
   }
 
 }


### PR DESCRIPTION
Allows the developer to get and update the local database from the live backup.

Testing

`composer global require xenomedia/xeno_robo:dev-dbrefresh`

On your local filesystem in an active project:

`robo db:refresh`

This does not run `go-local` as not all sites support that.



